### PR TITLE
Feat command battlefield

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.Rosstail</groupId>
     <artifactId>nodewar</artifactId>
-    <version>2.1.8</version>
+    <version>2.2.0</version>
     <packaging>jar</packaging>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.Rosstail</groupId>
     <artifactId>nodewar</artifactId>
-    <version>2.1.7</version>
+    <version>2.1.8</version>
     <packaging>jar</packaging>
 
     <distributionManagement>

--- a/src/main/java/fr/rosstail/nodewar/ConfigData.java
+++ b/src/main/java/fr/rosstail/nodewar/ConfigData.java
@@ -81,13 +81,15 @@ public class ConfigData {
         public final float configVersion;
         public final String defaultPermissionPlugin;
         public final boolean canCounterAttack;
+        public final boolean debugMode;
 
         ConfigGeneral(FileConfiguration config) {
             configFile = config;
 
-            configVersion = (float) config.getDouble("general.config-version", 1.0F);
+            configVersion = (float) config.getDouble("config-version", 1.0F); // Not in general cause top of file
             defaultPermissionPlugin = config.getString("general.permission-plugin", "auto");
             canCounterAttack = config.getBoolean("general.can-counter-attack", false);
+            debugMode = config.getBoolean("general.debug-mode", false);
         }
     }
 

--- a/src/main/java/fr/rosstail/nodewar/Nodewar.java
+++ b/src/main/java/fr/rosstail/nodewar/Nodewar.java
@@ -31,7 +31,6 @@ import org.bukkit.plugin.java.JavaPlugin;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.logging.Logger;
 
@@ -147,10 +146,10 @@ public class Nodewar extends JavaPlugin implements Listener {
 
         this.getCommand(getName().toLowerCase()).setExecutor(new CommandManager());
 
-        BattlefieldManager.getBattlefieldManager().loadBattlefieldList();
+        BattlefieldManager.getManager().loadBattlefieldList();
 
         PlayerDataManager.startDeployHandler();
-        BattlefieldManager.getBattlefieldManager().startBattlefieldDispatcher();
+        BattlefieldManager.getManager().startBattlefieldDispatcher();
     }
 
     private void initDefaultConfigs() {

--- a/src/main/java/fr/rosstail/nodewar/battlefield/Battlefield.java
+++ b/src/main/java/fr/rosstail/nodewar/battlefield/Battlefield.java
@@ -48,8 +48,10 @@ public class Battlefield {
         message = message.replaceAll("\\[battlefield_id]", String.valueOf(model.getId()));
         message = message.replaceAll("\\[battlefield_name]", model.getName());
         message = message.replaceAll("\\[battlefield_display]", model.getDisplay());
-        message = message.replaceAll("\\[battlefield_start_time]", AdaptMessage.getAdaptMessage().countdownFormatter(model.getOpenDateTime()));
-        message = message.replaceAll("\\[battlefield_close_time]", AdaptMessage.getAdaptMessage().countdownFormatter(model.getCloseDateTime()));
+        message = message.replaceAll("\\[battlefield_start_time]", AdaptMessage.getAdaptMessage().dateTimeFormatter(model.getOpenDateTime()));
+        message = message.replaceAll("\\[battlefield_start_time_left]", AdaptMessage.getAdaptMessage().countdownFormatter(model.getOpenDateTime()));
+        message = message.replaceAll("\\[battlefield_close_time]", AdaptMessage.getAdaptMessage().dateTimeFormatter(model.getCloseDateTime()));
+        message = message.replaceAll("\\[battlefield_close_time_left]", AdaptMessage.getAdaptMessage().countdownFormatter(model.getCloseDateTime()));
 
         boolean isOpen = model.isOpen();
         if (isOpen) {
@@ -58,6 +60,20 @@ public class Battlefield {
         } else {
             message = message.replaceAll("\\[battlefield_status]", LangManager.getMessage(LangMessage.BATTLEFIELD_CLOSED));
             message = message.replaceAll("\\[battlefield_delay]", AdaptMessage.getAdaptMessage().countdownFormatter(model.getOpenDateTime() - System.currentTimeMillis()));
+        }
+
+        if (message.contains("[battlefield_territory_list_line]")) {
+            StringBuilder territoryListStringBuilder = new StringBuilder();
+
+            territoryList.forEach(territory -> {
+                if (territoryList.indexOf(territory) > 0) {
+                    territoryListStringBuilder.append("\n");
+                }
+                territoryListStringBuilder.append(territory.adaptMessage(
+                        LangManager.getMessage(LangMessage.COMMANDS_BATTLEFIELD_CHECK_RESULT_TERRITORY_LIST_LINE)));
+            });
+
+            message = message.replaceAll("\\[battlefield_territory_list_line]", territoryListStringBuilder.toString());
         }
 
         return message;

--- a/src/main/java/fr/rosstail/nodewar/battlefield/Battlefield.java
+++ b/src/main/java/fr/rosstail/nodewar/battlefield/Battlefield.java
@@ -20,7 +20,7 @@ public class Battlefield {
     public Battlefield(BattlefieldModel model) {
         this.model = model;
 
-        BattlefieldManager.getBattlefieldManager().editBattlefieldAnouncementTimer(this, Math.min(model.getOpenDateTime(), model.getCloseDateTime()));
+        BattlefieldManager.getManager().editBattlefieldAnouncementTimer(this, Math.min(model.getOpenDateTime(), model.getCloseDateTime()));
 
         territoryList = TerritoryManager.getTerritoryManager().getTerritoryMap().values().stream().filter(territory -> (
                 model.getTerritoryList().contains(territory.getModel().getName())
@@ -45,6 +45,7 @@ public class Battlefield {
     }
 
     public String adaptMessage(String message) {
+        message = message.replaceAll("\\[battlefield_id]", String.valueOf(model.getId()));
         message = message.replaceAll("\\[battlefield_name]", model.getName());
         message = message.replaceAll("\\[battlefield_display]", model.getDisplay());
         message = message.replaceAll("\\[battlefield_start_time]", AdaptMessage.getAdaptMessage().countdownFormatter(model.getOpenDateTime()));
@@ -58,7 +59,6 @@ public class Battlefield {
             message = message.replaceAll("\\[battlefield_status]", LangManager.getMessage(LangMessage.BATTLEFIELD_CLOSED));
             message = message.replaceAll("\\[battlefield_delay]", AdaptMessage.getAdaptMessage().countdownFormatter(model.getOpenDateTime() - System.currentTimeMillis()));
         }
-
 
         return message;
     }

--- a/src/main/java/fr/rosstail/nodewar/battlefield/BattlefieldManager.java
+++ b/src/main/java/fr/rosstail/nodewar/battlefield/BattlefieldManager.java
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
 
 public class BattlefieldManager {
 
-    private static BattlefieldManager battlefieldManager;
+    private static BattlefieldManager manager;
     private final Nodewar plugin;
 
     private final List<Long> alertTimeList = new ArrayList<>();
@@ -35,8 +35,8 @@ public class BattlefieldManager {
     }
 
     public static void init(Nodewar plugin) {
-        if (battlefieldManager == null) {
-            battlefieldManager = new BattlefieldManager(plugin);
+        if (manager == null) {
+            manager = new BattlefieldManager(plugin);
         }
     }
 
@@ -242,8 +242,17 @@ public class BattlefieldManager {
         scheduler = Bukkit.getScheduler().scheduleSyncRepeatingTask(Nodewar.getInstance(), handleRequestExpiration, 20L, 20L);
     }
 
+    public List<Battlefield> getBattlefieldList() {
+        return battlefieldList;
+    }
+
+    public static BattlefieldManager getManager() {
+        return manager;
+    }
+
+    @Deprecated(forRemoval = true, since = "2.1.8")
     public static BattlefieldManager getBattlefieldManager() {
-        return battlefieldManager;
+        return manager;
     }
 
     public List<Long> getAlertTimeList() {

--- a/src/main/java/fr/rosstail/nodewar/battlefield/BattlefieldModel.java
+++ b/src/main/java/fr/rosstail/nodewar/battlefield/BattlefieldModel.java
@@ -38,8 +38,8 @@ public class BattlefieldModel {
         String[] startTimeStr = fromTimeStr.split(":");
         String[] endTimeStr = toTimeStr.split(":");
 
-        this.openDateTime = BattlefieldManager.getBattlefieldManager().getNextDayTime(DayOfWeek.valueOf(fromDayStr.toUpperCase()), Integer.parseInt(startTimeStr[0]), Integer.parseInt(startTimeStr[1]));
-        this.closeDateTime = BattlefieldManager.getBattlefieldManager().getNextDayTime(DayOfWeek.valueOf(toDayStr.toUpperCase()), Integer.parseInt(endTimeStr[0]), Integer.parseInt(endTimeStr[1]));
+        this.openDateTime = BattlefieldManager.getManager().getNextDayTime(DayOfWeek.valueOf(fromDayStr.toUpperCase()), Integer.parseInt(startTimeStr[0]), Integer.parseInt(startTimeStr[1]));
+        this.closeDateTime = BattlefieldManager.getManager().getNextDayTime(DayOfWeek.valueOf(toDayStr.toUpperCase()), Integer.parseInt(endTimeStr[0]), Integer.parseInt(endTimeStr[1]));
 
         this.resetTeam = section.getBoolean("reset-team", false);
         this.endBattleOnBattlefieldEnd = section.getBoolean("end-battle-on-battlefield-end", false);

--- a/src/main/java/fr/rosstail/nodewar/commands/CommandManager.java
+++ b/src/main/java/fr/rosstail/nodewar/commands/CommandManager.java
@@ -2,6 +2,7 @@ package fr.rosstail.nodewar.commands;
 
 import fr.rosstail.nodewar.commands.subcommands.HelpCommand;
 import fr.rosstail.nodewar.commands.subcommands.admin.AdminCommand;
+import fr.rosstail.nodewar.commands.subcommands.battlefield.BattlefieldCommand;
 import fr.rosstail.nodewar.commands.subcommands.team.TeamCommand;
 import fr.rosstail.nodewar.commands.subcommands.admin.territory.AdminTerritoryCommand;
 import fr.rosstail.nodewar.commands.subcommands.territory.TerritoryCommand;
@@ -34,6 +35,7 @@ public class CommandManager implements CommandExecutor, TabExecutor {
 
     public CommandManager() {
         subCommands.add(new AdminCommand());
+        subCommands.add(new BattlefieldCommand());
         subCommands.add(new TeamCommand());
         subCommands.add(new TerritoryCommand());
     }

--- a/src/main/java/fr/rosstail/nodewar/commands/subcommands/battlefield/BattlefieldCommand.java
+++ b/src/main/java/fr/rosstail/nodewar/commands/subcommands/battlefield/BattlefieldCommand.java
@@ -1,40 +1,30 @@
-package fr.rosstail.nodewar.commands.subcommands.team;
+package fr.rosstail.nodewar.commands.subcommands.battlefield;
 
 import fr.rosstail.nodewar.commands.CommandManager;
 import fr.rosstail.nodewar.commands.SubCommand;
-import fr.rosstail.nodewar.commands.subcommands.team.teamsubcommands.*;
-import fr.rosstail.nodewar.commands.subcommands.team.teamsubcommands.invites.TeamInvitesCommand;
-import fr.rosstail.nodewar.commands.subcommands.team.teamsubcommands.manage.TeamManageCommand;
+import fr.rosstail.nodewar.commands.subcommands.battlefield.battlefieldsubcommands.BattlefieldCheckCommand;
+import fr.rosstail.nodewar.commands.subcommands.battlefield.battlefieldsubcommands.BattlefieldListCommand;
 import fr.rosstail.nodewar.lang.AdaptMessage;
 import fr.rosstail.nodewar.lang.LangManager;
 import fr.rosstail.nodewar.lang.LangMessage;
-import fr.rosstail.nodewar.team.TeamManager;
-import fr.rosstail.nodewar.team.teammanagers.NwTeamManager;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class TeamCommand extends TeamSubCommand {
-    public List<TeamSubCommand> subCommands = new ArrayList<>();
+public class BattlefieldCommand extends BattlefieldSubCommand {
+    public List<BattlefieldSubCommand> subCommands = new ArrayList<>();
 
-    public TeamCommand() {
+    public BattlefieldCommand() {
         help = AdaptMessage.getAdaptMessage().adaptMessage(
                 LangManager.getMessage(LangMessage.COMMANDS_HELP_LINE)
-                        .replaceAll("\\[desc]", LangManager.getMessage(LangMessage.COMMANDS_TEAM_DESC))
+                        .replaceAll("\\[desc]", LangManager.getMessage(LangMessage.COMMANDS_BATTLEFIELD_DESC))
                         .replaceAll("\\[syntax]", getSyntax()));
-        subCommands.add(new TeamCheckCommand());
-        subCommands.add(new TeamListCommand());
-        subCommands.add(new TeamDeployCommand());
-        if (TeamManager.getManager().getUsedSystem() == null || TeamManager.getManager().getUsedSystem().equalsIgnoreCase("nodewar")) {
-            subCommands.add(new TeamInvitesCommand());
-            subCommands.add(new TeamCreateCommand());
-            subCommands.add(new TeamManageCommand());
-            subCommands.add(new TeamJoinCommand());
-            subCommands.add(new TeamLeaveCommand());
-        }
+        subCommands.add(new BattlefieldCheckCommand());
+        subCommands.add(new BattlefieldListCommand());
     }
+
 
     @Override
     public void perform(CommandSender sender, String[] args, String[] arguments) {
@@ -47,7 +37,7 @@ public class TeamCommand extends TeamSubCommand {
         }
 
         List<String> subCommandsStringList = new ArrayList<>();
-        for (TeamSubCommand subCommand : subCommands) {
+        for (BattlefieldSubCommand subCommand : subCommands) {
             subCommandsStringList.add(subCommand.getName());
         }
 
@@ -83,11 +73,11 @@ public class TeamCommand extends TeamSubCommand {
     public String getSubCommandHelp() {
         StringBuilder subCommandHelp = new StringBuilder(super.getSubCommandHelp());
         for (SubCommand subCommand : subCommands) {
+            System.out.println("YEAH");
             if (subCommand.getHelp() != null) {
                 subCommandHelp.append("\n").append(subCommand.getHelp());
             }
         }
         return subCommandHelp.toString();
     }
-
 }

--- a/src/main/java/fr/rosstail/nodewar/commands/subcommands/battlefield/BattlefieldSubCommand.java
+++ b/src/main/java/fr/rosstail/nodewar/commands/subcommands/battlefield/BattlefieldSubCommand.java
@@ -1,0 +1,31 @@
+package fr.rosstail.nodewar.commands.subcommands.battlefield;
+
+import fr.rosstail.nodewar.commands.SubCommand;
+import org.bukkit.entity.Player;
+
+import java.util.List;
+
+public abstract class BattlefieldSubCommand extends SubCommand {
+    @Override
+    public String getName() {
+        return "battlefield";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Battlefield command description";
+    }
+
+    @Override
+    public String getSyntax() {
+        return "nodewar battlefield <subcommand>";
+    }
+
+    @Override
+    public String getPermission() {
+        return "nodewar.command.battlefield";
+    }
+
+    @Override
+    public abstract List<String> getSubCommandsArguments(Player sender, String[] args, String[] arguments);
+}

--- a/src/main/java/fr/rosstail/nodewar/commands/subcommands/battlefield/battlefieldsubcommands/BattlefieldCheckCommand.java
+++ b/src/main/java/fr/rosstail/nodewar/commands/subcommands/battlefield/battlefieldsubcommands/BattlefieldCheckCommand.java
@@ -1,0 +1,77 @@
+package fr.rosstail.nodewar.commands.subcommands.battlefield.battlefieldsubcommands;
+
+import fr.rosstail.nodewar.battlefield.Battlefield;
+import fr.rosstail.nodewar.battlefield.BattlefieldManager;
+import fr.rosstail.nodewar.commands.CommandManager;
+import fr.rosstail.nodewar.commands.subcommands.battlefield.BattlefieldSubCommand;
+import fr.rosstail.nodewar.lang.AdaptMessage;
+import fr.rosstail.nodewar.lang.LangManager;
+import fr.rosstail.nodewar.lang.LangMessage;
+import fr.rosstail.nodewar.player.PlayerData;
+import fr.rosstail.nodewar.player.PlayerDataManager;
+import fr.rosstail.nodewar.team.NwITeam;
+import fr.rosstail.nodewar.team.TeamManager;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BattlefieldCheckCommand extends BattlefieldSubCommand {
+
+    public BattlefieldCheckCommand() {
+        help = AdaptMessage.getAdaptMessage().adaptMessage(
+                LangManager.getMessage(LangMessage.COMMANDS_HELP_LINE)
+                        .replaceAll("\\[desc]", LangManager.getMessage(LangMessage.COMMANDS_BATTLEFIELD_CHECK_DESC))
+                        .replaceAll("\\[syntax]", getSyntax()));
+    }
+
+    @Override
+    public String getName() {
+        return "check";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Display info of a battlefield";
+    }
+
+    @Override
+    public String getSyntax() {
+        return "nodewar battlefield check <battlefield>";
+    }
+
+    @Override
+    public String getHelp() {
+        return super.getHelp();
+    }
+
+    @Override
+    public void perform(CommandSender sender, String[] args, String[] arguments) {
+        Battlefield battlefield;
+        if (!CommandManager.canLaunchCommand(sender, this)) {
+            return;
+        }
+
+        if (args.length < 3) {
+            sender.sendMessage(LangManager.getMessage(LangMessage.COMMANDS_TOO_FEW_ARGUMENTS));
+            return;
+        }
+
+        battlefield = BattlefieldManager.getManager().getBattlefieldList().stream()
+                .filter(battlefield1 -> battlefield1.getModel().getName().equalsIgnoreCase(args[2])).findFirst().orElse(null);
+
+        if (battlefield != null) {
+            sender.sendMessage(battlefield.adaptMessage(LangManager.getMessage(LangMessage.COMMANDS_BATTLEFIELD_CHECK_RESULT)));
+        } else {
+            sender.sendMessage(AdaptMessage.getAdaptMessage().adaptMessage(
+                    LangManager.getMessage(LangMessage.COMMANDS_WRONG_VALUE).replaceAll("\\[value]", args[2])
+            ));
+        }
+    }
+
+    @Override
+    public List<String> getSubCommandsArguments(Player sender, String[] args, String[] arguments) {
+        return BattlefieldManager.getManager().getBattlefieldList().stream().map(battlefield -> battlefield.getModel().getName()).toList();
+    }
+}

--- a/src/main/java/fr/rosstail/nodewar/commands/subcommands/battlefield/battlefieldsubcommands/BattlefieldListCommand.java
+++ b/src/main/java/fr/rosstail/nodewar/commands/subcommands/battlefield/battlefieldsubcommands/BattlefieldListCommand.java
@@ -1,0 +1,86 @@
+package fr.rosstail.nodewar.commands.subcommands.battlefield.battlefieldsubcommands;
+
+import fr.rosstail.nodewar.battlefield.Battlefield;
+import fr.rosstail.nodewar.battlefield.BattlefieldManager;
+import fr.rosstail.nodewar.commands.CommandManager;
+import fr.rosstail.nodewar.commands.subcommands.battlefield.BattlefieldSubCommand;
+import fr.rosstail.nodewar.lang.AdaptMessage;
+import fr.rosstail.nodewar.lang.LangManager;
+import fr.rosstail.nodewar.lang.LangMessage;
+import fr.rosstail.nodewar.team.NwITeam;
+import fr.rosstail.nodewar.team.TeamManager;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class BattlefieldListCommand extends BattlefieldSubCommand {
+
+    public BattlefieldListCommand() {
+        help = AdaptMessage.getAdaptMessage().adaptMessage(
+                LangManager.getMessage(LangMessage.COMMANDS_HELP_LINE)
+                        .replaceAll("\\[desc]", LangManager.getMessage(LangMessage.COMMANDS_BATTLEFIELD_LIST_DESC))
+                        .replaceAll("\\[syntax]", getSyntax()));
+    }
+
+    @Override
+    public String getName() {
+        return "list";
+    }
+
+    @Override
+    public String getDescription() {
+        return "List of battlefields";
+    }
+
+    @Override
+    public String getSyntax() {
+        return "nodewar battlefield list (page)";
+    }
+
+    @Override
+    public List<String> getSubCommandsArguments(Player sender, String[] args, String[] arguments) {
+        return List.of();
+    }
+
+    @Override
+    public String getHelp() {
+        return super.getHelp();
+    }
+
+    @Override
+    public void perform(CommandSender sender, String[] args, String[] arguments) {
+        StringBuilder message = new StringBuilder(LangManager.getMessage(LangMessage.COMMANDS_BATTLEFIELD_LIST_RESULT_HEADER));
+        int page = 0;
+
+        List<Battlefield> battlefieldList = BattlefieldManager.getManager().getBattlefieldList();
+        List<String> strList = battlefieldList.stream().map(battlefield -> battlefield.getModel().getName()).toList();
+        int size = strList.size();
+        int maxPage = size / 10;
+        if (!CommandManager.canLaunchCommand(sender, this)) {
+            return;
+        }
+
+        if (args.length >= 3) {
+            page = Integer.parseInt(args[2]);
+        }
+
+        if (page < 0 || page > maxPage) {
+            return;
+        }
+
+        if (size > 0) {
+            for (int i = page * 10; i < Math.min(size, page * 10 + 10); i++) {
+                String s = strList.get(i);
+                Battlefield battlefield = battlefieldList.stream().filter(battlefield1 -> battlefield1.getModel().getName().equals(s)).findFirst().get();
+                message.append("\n").append(battlefield.adaptMessage(LangManager.getMessage(LangMessage.COMMANDS_BATTLEFIELD_LIST_RESULT_LINE)));
+            }
+            message.append("\nP." + (page + 1) + "/" + (maxPage + 1));
+        } else {
+            message.append("\n&rP.0/0");
+        }
+        sender.sendMessage(AdaptMessage.getAdaptMessage().adaptMessage(message.toString()));
+    }
+}

--- a/src/main/java/fr/rosstail/nodewar/commands/subcommands/battlefield/battlefieldsubcommands/BattlefieldListCommand.java
+++ b/src/main/java/fr/rosstail/nodewar/commands/subcommands/battlefield/battlefieldsubcommands/BattlefieldListCommand.java
@@ -58,16 +58,16 @@ public class BattlefieldListCommand extends BattlefieldSubCommand {
         List<Battlefield> battlefieldList = BattlefieldManager.getManager().getBattlefieldList();
         List<String> strList = battlefieldList.stream().map(battlefield -> battlefield.getModel().getName()).toList();
         int size = strList.size();
-        int maxPage = size / 10;
+        int maxPage = (int) Math.ceil((float) size / 10);
         if (!CommandManager.canLaunchCommand(sender, this)) {
             return;
         }
 
         if (args.length >= 3) {
-            page = Integer.parseInt(args[2]);
+            page = Integer.parseInt(args[2]) - 1;
         }
 
-        if (page < 0 || page > maxPage) {
+        if (page < 0 || page >= maxPage) {
             return;
         }
 
@@ -77,7 +77,7 @@ public class BattlefieldListCommand extends BattlefieldSubCommand {
                 Battlefield battlefield = battlefieldList.stream().filter(battlefield1 -> battlefield1.getModel().getName().equals(s)).findFirst().get();
                 message.append("\n").append(battlefield.adaptMessage(LangManager.getMessage(LangMessage.COMMANDS_BATTLEFIELD_LIST_RESULT_LINE)));
             }
-            message.append("\nP." + (page + 1) + "/" + (maxPage + 1));
+            message.append("\nP." + (page + 1) + "/" + maxPage);
         } else {
             message.append("\n&rP.0/0");
         }

--- a/src/main/java/fr/rosstail/nodewar/commands/subcommands/team/teamsubcommands/TeamListCommand.java
+++ b/src/main/java/fr/rosstail/nodewar/commands/subcommands/team/teamsubcommands/TeamListCommand.java
@@ -57,16 +57,16 @@ public class TeamListCommand extends TeamSubCommand {
         Map<String, NwITeam> stringNwITeamMap = TeamManager.getManager().getStringTeamMap();
         List<String> strList = TeamManager.getManager().getStringTeamMap().keySet().stream().sorted().collect(Collectors.toList());
         int size = strList.size();
-        int maxPage = size / 10;
+        int maxPage = (int) Math.ceil((float) size / 10);
         if (!CommandManager.canLaunchCommand(sender, this)) {
             return;
         }
 
         if (args.length >= 3) {
-            page = Integer.parseInt(args[2]);
+            page = Integer.parseInt(args[2]) - 1;
         }
 
-        if (page < 0 || page > maxPage) {
+        if (page < 0 || page >= maxPage) {
             return;
         }
 
@@ -76,7 +76,7 @@ public class TeamListCommand extends TeamSubCommand {
                 NwITeam nwTeam = stringNwITeamMap.get(s);
                 message.append("\n").append(AdaptMessage.getAdaptMessage().adaptTeamMessage(LangManager.getMessage(LangMessage.COMMANDS_TEAM_LIST_RESULT_LINE), nwTeam));
             }
-            message.append("\nP." + (page + 1) + "/" + (maxPage + 1));
+            message.append("\nP." + (page + 1) + "/" + maxPage);
         } else {
             message.append("\n&rP.0/0");
         }

--- a/src/main/java/fr/rosstail/nodewar/events/MinecraftEventHandler.java
+++ b/src/main/java/fr/rosstail/nodewar/events/MinecraftEventHandler.java
@@ -1,6 +1,8 @@
 package fr.rosstail.nodewar.events;
 
+import fr.rosstail.nodewar.ConfigData;
 import fr.rosstail.nodewar.Nodewar;
+import fr.rosstail.nodewar.lang.AdaptMessage;
 import fr.rosstail.nodewar.permissionmannager.PermissionManager;
 import fr.rosstail.nodewar.player.PlayerData;
 import fr.rosstail.nodewar.player.PlayerDataManager;
@@ -63,6 +65,13 @@ public class MinecraftEventHandler implements Listener {
             StorageManager.getManager().insertPlayerModel(playerData);
         } else {
             playerData = new PlayerData(player, playerModel);
+            if (!playerData.getUsername().equals(playerName)) {
+                if (ConfigData.getConfigData().general.debugMode) {
+                    AdaptMessage.print("[NW] Updating model name from " + playerData.getUsername() + " to " + playerName, AdaptMessage.prints.WARNING);
+                }
+                playerData.setUsername(playerName);
+                StorageManager.getManager().updatePlayerModel(playerData, true);
+            }
         }
 
         PlayerDataManager.initPlayerDataToMap(playerData);

--- a/src/main/java/fr/rosstail/nodewar/lang/AdaptMessage.java
+++ b/src/main/java/fr/rosstail/nodewar/lang/AdaptMessage.java
@@ -215,12 +215,10 @@ public class AdaptMessage {
         message = message.replaceAll(starter + ender, playerModel.getUsername());
         message = message.replaceAll(starter + "_uuid" + ender, playerModel.getUuid());
 
-        SimpleDateFormat simpleDateFormat = new SimpleDateFormat(LangManager.getMessage(LangMessage.FORMAT_DATETIME));
-
         message = message.replaceAll(starter + "_status" + ender,
                 LangManager.getMessage(isPlayerOnline ? LangMessage.PLAYER_ONLINE : LangMessage.PLAYER_OFFLINE));
 
-        message = message.replaceAll(starter + "_last_update" + ender, playerModel.getLastUpdate() > 0L ? simpleDateFormat.format(playerModel.getLastUpdate()) : LangManager.getMessage(LangMessage.FORMAT_DATETIME_NEVER));
+        message = message.replaceAll(starter + "_last_update" + ender, playerModel.getLastUpdate() > 0L ? dateTimeFormatter(playerModel.getLastUpdate()) : LangManager.getMessage(LangMessage.FORMAT_DATETIME_NEVER));
         return adaptMessage(message);
     }
 
@@ -328,6 +326,12 @@ public class AdaptMessage {
         return String.format("%." + decimal + "f", value).replaceAll(",", String.valueOf(replacement));
     }
 
+
+    public String dateTimeFormatter(long datetime) {
+        SimpleDateFormat simpleDateFormat = new SimpleDateFormat(LangManager.getMessage(LangMessage.FORMAT_DATETIME));
+
+        return simpleDateFormat.format(datetime);
+    }
     /**
      * Format the given value to a formatted String depending on the config.
      *

--- a/src/main/java/fr/rosstail/nodewar/lang/LangMessage.java
+++ b/src/main/java/fr/rosstail/nodewar/lang/LangMessage.java
@@ -113,6 +113,7 @@ public enum LangMessage {
     COMMANDS_BATTLEFIELD_DESC("commands.battlefield.desc", false, false),
     COMMANDS_BATTLEFIELD_CHECK_DESC("commands.battlefield.check.desc", false, false),
     COMMANDS_BATTLEFIELD_CHECK_RESULT("commands.battlefield.check.result", false, true),
+    COMMANDS_BATTLEFIELD_CHECK_RESULT_TERRITORY_LIST_LINE("commands.battlefield.check.result-territory-list-line", false, false),
     COMMANDS_BATTLEFIELD_LIST_DESC("commands.battlefield.list.desc", false, false),
     COMMANDS_BATTLEFIELD_LIST_RESULT_HEADER("commands.battlefield.list.result-header", false, false),
     COMMANDS_BATTLEFIELD_LIST_RESULT_LINE("commands.battlefield.list.result-line", false, false),

--- a/src/main/java/fr/rosstail/nodewar/lang/LangMessage.java
+++ b/src/main/java/fr/rosstail/nodewar/lang/LangMessage.java
@@ -109,6 +109,14 @@ public enum LangMessage {
     COMMANDS_TERRITORY_CHECK_RESULT("commands.territory.check.result", false, true),
     COMMANDS_TERRITORY_CHECK_RESULT_NOT_ON_TERRITORY("commands.territory.check.result-not-on-territory", false, false),
     COMMANDS_TERRITORY_CHECK_RESULT_ON_MULTIPLE_TERRITORY("commands.territory.check.result-on-multiple-territory", false, false),
+
+    COMMANDS_BATTLEFIELD_DESC("commands.battlefield.desc", false, false),
+    COMMANDS_BATTLEFIELD_CHECK_DESC("commands.battlefield.check.desc", false, false),
+    COMMANDS_BATTLEFIELD_CHECK_RESULT("commands.battlefield.check.result", false, true),
+    COMMANDS_BATTLEFIELD_LIST_DESC("commands.battlefield.list.desc", false, false),
+    COMMANDS_BATTLEFIELD_LIST_RESULT_HEADER("commands.battlefield.list.result-header", false, false),
+    COMMANDS_BATTLEFIELD_LIST_RESULT_LINE("commands.battlefield.list.result-line", false, false),
+
     COMMANDS_ADMIN_DESC("commands.admin.desc", false, false),
     COMMANDS_ADMIN_TEAM_DESC("commands.admin.team.desc", false, false),
     COMMANDS_ADMIN_TEAM_CREATE_DESC("commands.admin.team.create.desc", false, false),

--- a/src/main/java/fr/rosstail/nodewar/player/PlayerModel.java
+++ b/src/main/java/fr/rosstail/nodewar/player/PlayerModel.java
@@ -29,7 +29,6 @@ public class PlayerModel {
     public PlayerModel(String uuid, String username) {
         this.uuid = uuid;
         this.username = username;
-        this.checkForData();
     }
 
     /**

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,3 +1,5 @@
+config-version: 1.0
+
 storage:
   type: SQLite # SQLite (local storage), MySQL, MariaDB, MongoDB
   host: "localhost"
@@ -8,9 +10,9 @@ storage:
   save-delay: 300
 
 general:
-  debug-messages: true
   permission-plugin: auto # luckperms, GroupManager, and "auto". Ask the dev to add others
   can-counter-attack: false # Can a team attack another territory from a territory already in battle
+  debug-mode: false
 
 locale:
   lang: en_EN

--- a/src/main/resources/lang/en_EN.yml
+++ b/src/main/resources/lang/en_EN.yml
@@ -259,13 +259,14 @@ commands:
     check:
       desc: "Check status of a battlefield"
       result:
-        - "&2[battlefield_id] &7- &6[battlefield_display]&r&d:"
-        - "  &r&9Info&d:"
-        - "    &c* &6Status&d:&r [battlefield_status] for [battlefield_delay]"
-        - "    &c* &6Opens in&d:&r [battlefield_start_time]"
-        - "    &c* &6Closes in&d:&r [battlefield_close_time]"
-        - "    &c* &6Territories:&r<TODO>"
-        - "    &c* &6Territory Types:&r<TODO>"
+        - "[prefix]&2[battlefield_id] &7- &6[battlefield_display] &r&d:"
+        - "  &r&9Info &d:"
+        - "    &c* &6Status &d:&r [battlefield_status] for [battlefield_delay]"
+        - "    &c* &6Opens at &d:&r [battlefield_start_time] for [battlefield_duration]"
+        - "    &c* &6Closes at &d:&r [battlefield_close_time]"
+        - "    &c* &6Territories &d:&r"
+        - "[battlefield_territory_list_line]"
+      result-territory-list-line: "      &5 - &r[territory_display] [territory_team_color_short]&r"
     list:
       desc: "Check the list of battlefields"
       result-header: "[prefix]&bBattlefield list &8:"

--- a/src/main/resources/lang/en_EN.yml
+++ b/src/main/resources/lang/en_EN.yml
@@ -266,7 +266,7 @@ commands:
         - "    &c* &6Closes at &d:&r [battlefield_close_time]"
         - "    &c* &6Territories &d:&r"
         - "[battlefield_territory_list_line]"
-      result-territory-list-line: "      &5 - &r[territory_display] [territory_team_color_short]&r"
+      result-territory-list-line: "      &5 - &r[territory_display] [territory_team_color_display]&r"
     list:
       desc: "Check the list of battlefields"
       result-header: "[prefix]&bBattlefield list &8:"

--- a/src/main/resources/lang/en_EN.yml
+++ b/src/main/resources/lang/en_EN.yml
@@ -254,6 +254,22 @@ commands:
         - "[territory_battle_description]"
       result-not-on-territory: "You are not standing on a territory"
       result-on-multiple-territory: "You are standing on multiple territories: please select one of them: [territories]"
+  battlefield:
+    desc: "Battlefield commands"
+    check:
+      desc: "Check status of a battlefield"
+      result:
+        - "&2[battlefield_id] &7- &6[battlefield_display]&r&d:"
+        - "  &r&9Info&d:"
+        - "    &c* &6Status&d:&r [battlefield_status] for [battlefield_delay]"
+        - "    &c* &6Opens in&d:&r [battlefield_start_time]"
+        - "    &c* &6Closes in&d:&r [battlefield_close_time]"
+        - "    &c* &6Territories:&r<TODO>"
+        - "    &c* &6Territory Types:&r<TODO>"
+    list:
+      desc: "Check the list of battlefields"
+      result-header: "[prefix]&bBattlefield list &8:"
+      result-line: "&a► [battlefield_display] ([battlefield_name])&r is [battlefield_status] for [battlefield_delay]"
 
 player:
   online: "&aONLINE"

--- a/src/main/resources/lang/fr_FR.yml
+++ b/src/main/resources/lang/fr_FR.yml
@@ -1,7 +1,7 @@
 prefix: "&f[&cNW&f]&r "
 
 format:
-  datetime: "yyyy-MM-dd HH:mm:ss"
+  datetime: "dd-MM-yyyy HH:mm:ss"
   datetime-never: "&7Jamais"
   countdown: "{dd}d {HH}:{mm}:{ss}" #use dd, d, hh, h, mm, m, ss, s
 
@@ -260,10 +260,11 @@ commands:
         - "[prefix]&2[battlefield_id] &7- &6[battlefield_display]&r&d:"
         - "  &r&9Info&d:"
         - "    &c* &6Statut&d:&r [battlefield_status] pour encore [battlefield_delay]"
-        - "    &c* &6Ouvre dans &d:&r [battlefield_start_time]"
-        - "    &c* &6Ferme dans &d:&r [battlefield_close_time]"
-        - "    &c* &6Territoires:&r<TODO>"
-        - "    &c* &6Types de territoire:&r<TODO>"
+        - "    &c* &6Ouvre le &d:&r [battlefield_start_time]"
+        - "    &c* &6Ferme le &d:&r [battlefield_close_time]"
+        - "    &c* &6Territoires &d:&r"
+        - "[battlefield_territory_list_line]"
+      result-territory-list-line: "      &5 - &r[territory_display] [territory_team_color_short]&r"
     list:
       desc: "Voir la liste des champs de bataille"
       result-header: "[prefix]&bChamps de bataille &8:"

--- a/src/main/resources/lang/fr_FR.yml
+++ b/src/main/resources/lang/fr_FR.yml
@@ -1,7 +1,7 @@
 prefix: "&f[&cNW&f]&r "
 
 format:
-  datetime: "dd-MM-yyyy HH:mm:ss"
+  datetime: "dd/MM/yyyy HH:mm:ss"
   datetime-never: "&7Jamais"
   countdown: "{dd}d {HH}:{mm}:{ss}" #use dd, d, hh, h, mm, m, ss, s
 
@@ -264,7 +264,7 @@ commands:
         - "    &c* &6Ferme le &d:&r [battlefield_close_time]"
         - "    &c* &6Territoires &d:&r"
         - "[battlefield_territory_list_line]"
-      result-territory-list-line: "      &5 - &r[territory_display] [territory_team_color_short]&r"
+      result-territory-list-line: "      &5 - &r[territory_display] [territory_team_color_display]&r"
     list:
       desc: "Voir la liste des champs de bataille"
       result-header: "[prefix]&bChamps de bataille &8:"

--- a/src/main/resources/lang/fr_FR.yml
+++ b/src/main/resources/lang/fr_FR.yml
@@ -252,6 +252,22 @@ commands:
         - "[territory_battle_description]"
       result-not-on-territory: "Vous ne vous tenez pas sur un territoire"
       result-on-multiple-territory: "Vous vous tenez sur plusieurs territoires à la fois. Veuillez en sélectionner un: [territories]"
+  battlefield:
+    desc: "Commandes de champ de bataille"
+    check:
+      desc: "Observez l'état d'un champ de bataille"
+      result:
+        - "[prefix]&2[battlefield_id] &7- &6[battlefield_display]&r&d:"
+        - "  &r&9Info&d:"
+        - "    &c* &6Statut&d:&r [battlefield_status] pour encore [battlefield_delay]"
+        - "    &c* &6Ouvre dans &d:&r [battlefield_start_time]"
+        - "    &c* &6Ferme dans &d:&r [battlefield_close_time]"
+        - "    &c* &6Territoires:&r<TODO>"
+        - "    &c* &6Types de territoire:&r<TODO>"
+    list:
+      desc: "Voir la liste des champs de bataille"
+      result-header: "[prefix]&bChamps de bataille &8:"
+      result-line: "&a► [battlefield_display] ([battlefield_name])&r est [battlefield_status] pour encore [battlefield_delay]"
 
 player:
   online: "&aEN LIGNE"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -156,6 +156,19 @@ permissions:
       nodewar.command.territory: true
       nodewar.command.territory.check: true
 
+  nodewar.command.battlefield:
+    default: true
+  nodewar.command.battlefield.check:
+    default: true
+  nodewar.command.battlefield.list:
+    default: true
+  nodewar.command.battlefield.*:
+    default: op
+    children:
+      nodewar.command.battlefield: true
+      nodewar.command.battlefield.check: true
+      nodewar.command.battlefield.list: true
+
   nodewar.command.*:
     default: op
     children:
@@ -163,6 +176,7 @@ permissions:
       nodewar.command.admin: true
       nodewar.command.team.*: true
       nodewar.command.territory.*: true
+      nodewar.command.battlefield.*: true
 
   nodewar.*:
     default: op


### PR DESCRIPTION
- Added the `/nodewar battlefield` command
- `/nodewar battlefield list (page)` helps tracking multiple battlefields (1 battlefield per line)
- `/nodewar battlefield check <battlefield-name>` displays all infos from a battlefield (status, opening, closures, territories, etc...)
- The commands are bound to the `nodewar.commands.battlefield` permission.
- The description and result messages of these commands can be edited in the locale files.

- Added and changed some placeholders for the battlefields.
- Fixed `/nodewar team list` not showing the proper amount of pages.
- [Updated localization files](https://www.youtube.com/watch?v=mFEUwicql6E)